### PR TITLE
Allow jobs to be defined as coroutines

### DIFF
--- a/django_dbq/models.py
+++ b/django_dbq/models.py
@@ -11,6 +11,7 @@ from django.db.models import UUIDField, Count
 import datetime
 import logging
 import uuid
+from django_dbq.utils import run_job
 
 
 logger = logging.getLogger(__name__)
@@ -137,7 +138,7 @@ class Job(models.Model):
         if creation_hook_name:
             logger.info("Running creation hook %s for new job", creation_hook_name)
             creation_hook_function = import_string(creation_hook_name)
-            creation_hook_function(self)
+            run_job(creation_hook_function, self)
 
     @staticmethod
     def get_queue_depths():

--- a/django_dbq/utils.py
+++ b/django_dbq/utils.py
@@ -1,0 +1,8 @@
+import asyncio
+
+
+def run_job(job_function, *args, **kwargs):
+    if asyncio.iscoroutinefunction(job_function):
+        asyncio.run(job_function(*args, **kwargs))
+    else:
+        job_function(*args, **kwargs)


### PR DESCRIPTION
For some libraries, it's necessary to use async code, even if it's in a single process where the async benefits don't apply.

This transparently calls a job function as a coroutine if it is one, allow jobs defined `async def my_job(job):` to "just work" :tm:.

Note that this doesn't use a shared event loop, it simply starts one at execution time.