### PR TITLE
Add Django 4.0 and Python 3.10 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        django: [3.2, 4.0]
+        python: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        django: ["3.2", "4.0"]
         exclude:
-          - python: 3.6
-            django: 4.0
-          - python: 3.7
-            django: 4.0
+          - python: "3.6"
+            django: "4.0"
+          - python: "3.7"
+            django: "4.0"
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,12 @@ jobs:
     strategy:
       matrix:
         python: [3.6, 3.7, 3.8, 3.9, "3.10"]
-        django: [2.2, 3.2, 4.0]
+        django: [3.2, 4.0]
         exclude:
           - python: 3.6
             django: 4.0
           - python: 3.7
             django: 4.0
-          - python: "3.10"
-            django: 2.2
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,15 @@ jobs:
 
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
-        django: [3.1, 3.2]
+        python: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        django: [2.2, 3.2, 4.0]
+        exclude:
+          - python: 3.6
+            django: 4.0
+          - python: 3.7
+            django: 4.0
+          - python: "3.10"
+            django: 2.2
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Simple database-backed job queue. Jobs are defined in your settings, and are pro
 Asynchronous tasks are run via a *job queue*. This system is designed to support multi-step job workflows.
 
 Supported and tested against:
-- Django 3.1 and 3.2
-- Python 3.6, 3.7, 3.8 and 3.9
+- Django 3.2 and 4.0
+- Python 3.6, 3.7, 3.8, 3.9 and 3.10
 
 ## Getting Started
 


### PR DESCRIPTION
Remove unsupported versions.