### PR TITLE
Add Django 5 and Python 3.12 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
             django: "4.0"
           - python: "3.12"
             django: "4.0"
+          - python: "3.8"
+            django: "5.0"
+          - python: "3.9"
+            django: "5.0"
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,16 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11"]
-        django: ["3.2", "4.0", "4.1", "4.2"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        django: ["3.2", "4.0", "4.1", "4.2", "5.0"]
         exclude:
           - python: "3.11"
             django: "3.2"
+          - python: "3.12"
+            django: "3.2"
           - python: "3.11"
+            django: "4.0"
+          - python: "3.12"
             django: "4.0"
         database_url:
           - postgres://runner:password@localhost/project

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Simple database-backed job queue. Jobs are defined in your settings, and are pro
 Asynchronous tasks are run via a *job queue*. This system is designed to support multi-step job workflows.
 
 Supported and tested against:
-- Django 3.2, 4.0, 4.1, 4.2
-- Python 3.8, 3.9, 3.10, 3.11
+- Django 3.2, 4.0, 4.1, 4.2, 5.0
+- Python 3.8, 3.9, 3.10, 3.11, 3.12
 
 ## Getting Started
 

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -17,6 +17,7 @@ try:
     utc = timezone.utc
 except AttributeError:
     from datetime import timezone as datetime_timezone
+
     utc = datetime_timezone.utc
 
 
@@ -238,7 +239,9 @@ class JobTestCase(TestCase):
 
     def test_ignores_jobs_until_run_after_is_in_the_past(self):
         job_1 = Job.objects.create(name="testjob")
-        job_2 = Job.objects.create(name="testjob", run_after=datetime(2021, 11, 4, 8, tzinfo=utc))
+        job_2 = Job.objects.create(
+            name="testjob", run_after=datetime(2021, 11, 4, 8, tzinfo=utc)
+        )
 
         with freezegun.freeze_time(datetime(2021, 11, 4, 7)):
             self.assertEqual(

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -13,6 +13,13 @@ from django_dbq.models import Job
 from io import StringIO
 
 
+try:
+    utc = timezone.utc
+except AttributeError:
+    from datetime import timezone as datetime_timezone
+    utc = datetime_timezone.utc
+
+
 def test_task(job=None):
     pass  # pragma: no cover
 
@@ -189,7 +196,7 @@ class JobTestCase(TestCase):
         Job.objects.create(name="testjob", state=Job.STATES.READY)
         Job.objects.create(name="testjob", state=Job.STATES.PROCESSING)
         expected = Job.objects.create(name="testjob", state=Job.STATES.READY)
-        expected.created = datetime.now() - timedelta(minutes=1)
+        expected.created = timezone.now() - timedelta(minutes=1)
         expected.save()
 
         self.assertEqual(Job.objects.get_ready_or_none("default"), expected)
@@ -231,7 +238,7 @@ class JobTestCase(TestCase):
 
     def test_ignores_jobs_until_run_after_is_in_the_past(self):
         job_1 = Job.objects.create(name="testjob")
-        job_2 = Job.objects.create(name="testjob", run_after=datetime(2021, 11, 4, 8))
+        job_2 = Job.objects.create(name="testjob", run_after=datetime(2021, 11, 4, 8, tzinfo=utc))
 
         with freezegun.freeze_time(datetime(2021, 11, 4, 7)):
             self.assertEqual(
@@ -256,7 +263,7 @@ class JobTestCase(TestCase):
         Job.objects.create(name="testjob", state=Job.STATES.NEW)
         Job.objects.create(name="testjob", state=Job.STATES.PROCESSING)
         expected = Job.objects.create(name="testjob", state=Job.STATES.NEW)
-        expected.created = datetime.now() - timedelta(minutes=1)
+        expected.created = timezone.now() - timedelta(minutes=1)
         expected.save()
 
         self.assertEqual(Job.objects.get_ready_or_none("default"), expected)
@@ -336,7 +343,7 @@ class JobFailureHookTestCase(TestCase):
 @override_settings(JOBS={"testjob": {"tasks": ["a"]}})
 class DeleteOldJobsTestCase(TestCase):
     def test_delete_old_jobs(self):
-        two_days_ago = datetime.utcnow() - timedelta(days=2)
+        two_days_ago = timezone.now() - timedelta(days=2)
 
         j1 = Job.objects.create(name="testjob", state=Job.STATES.COMPLETE)
         j1.created = two_days_ago

--- a/testsettings.py
+++ b/testsettings.py
@@ -19,3 +19,5 @@ LOGGING = {
     "root": {"handlers": ["console"], "level": "INFO",},
     "loggers": {"django_dbq": {"level": "CRITICAL", "propagate": True,},},
 }
+
+USE_TZ = True


### PR DESCRIPTION
Also unpins the postgres image version (so we'll use the latest) and fixes a bunch of issues with naive timezones that were actually breaking tests on Django 5.