### PR TITLE
Add support for customising the age of jobs that are deleted by the delete_old_jobs command

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,7 @@ in the dict returned by this method.
 ##### manage.py delete_old_jobs
 There is a management command, `manage.py delete_old_jobs`, which deletes any
 jobs from the database which are in state `COMPLETE` or `FAILED` and were
-created more than 24 hours ago. This could be run, for example, as a cron task,
-to ensure the jobs table remains at a reasonable size.
+created more than (by default) 24 hours ago. This could be run, for example, as a cron task, to ensure the jobs table remains at a reasonable size. Use the `--hours` argument to control the age of jobs that will be deleted.
 
 ##### manage.py worker
 To start a worker:

--- a/django_dbq/management/commands/delete_old_jobs.py
+++ b/django_dbq/management/commands/delete_old_jobs.py
@@ -6,6 +6,15 @@ class Command(BaseCommand):
 
     help = "Delete old jobs"
 
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--hours",
+            help="Delete jobs older than this many hours",
+            default=None,
+            required=False,
+            type=int,
+        )
+
     def handle(self, *args, **options):
-        Job.objects.delete_old()
+        Job.objects.delete_old(hours=options["hours"])
         self.stdout.write("Deleted old jobs")

--- a/django_dbq/models.py
+++ b/django_dbq/models.py
@@ -15,7 +15,7 @@ import uuid
 logger = logging.getLogger(__name__)
 
 
-DELETE_JOBS_AFTER_HOURS = 24
+DEFAULT_DELETE_JOBS_AFTER_HOURS = 24
 
 
 class JobManager(models.Manager):
@@ -49,9 +49,9 @@ class JobManager(models.Manager):
                     retries_left,
                 )
 
-    def delete_old(self):
+    def delete_old(self, hours=None):
         """
-        Delete all jobs older than DELETE_JOBS_AFTER_HOURS
+        Delete all jobs older than hours, or DEFAULT_DELETE_JOBS_AFTER_HOURS
         """
         delete_jobs_in_states = [
             Job.STATES.FAILED,
@@ -59,7 +59,7 @@ class JobManager(models.Manager):
             Job.STATES.STOPPING,
         ]
         delete_jobs_created_before = timezone.now() - datetime.timedelta(
-            hours=DELETE_JOBS_AFTER_HOURS
+            hours=hours or DEFAULT_DELETE_JOBS_AFTER_HOURS
         )
         logger.info(
             "Deleting all job in states %s created before %s",

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -371,3 +371,17 @@ class DeleteOldJobsTestCase(TestCase):
         self.assertEqual(Job.objects.count(), 2)
         self.assertTrue(j4 in Job.objects.all())
         self.assertTrue(j5 in Job.objects.all())
+
+    def test_delete_old_jobs_with_custom_hours_argument(self):
+        j1 = Job.objects.create(name="testjob", state=Job.STATES.COMPLETE)
+        j1.created = timezone.now() - timedelta(days=5)
+        j1.save()
+
+        j2 = Job.objects.create(name="testjob", state=Job.STATES.COMPLETE)
+        j2.created = timezone.now() - timedelta(days=3)
+        j2.save()
+
+        Job.objects.delete_old(hours=24 * 4)
+
+        self.assertEqual(Job.objects.count(), 1)
+        self.assertTrue(j2 in Job.objects.all())


### PR DESCRIPTION
This adds an optional flag `--hours` to the `manage.py delete_old_jobs` command, which allows the user to override the age of jobs that are to be deleted. For example, if you'd like to keep jobs for a week, use `python manage.py delete_old_jobs --hours=168`