### PR TITLE
Add Python 3.13 and Django 5.1 to test matrix, drop unsupported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,13 @@ jobs:
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python }}
+        python-version: ${{ matrix.python }}.*
     - name: Upgraded pip
       run: pip install --upgrade pip
     - name: Install dependencies
       run: pip install -r test-requirements.txt
     - name: Install Django
-      run: pip install -U django==${{ matrix.django }}
+      run: pip install -U django~=${{ matrix.django }}.0
     - name: Run tests
       run: python manage.py test
     - name: Run black

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,21 +9,13 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        django: ["3.2", "4.0", "4.1", "4.2", "5.0"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        django: ["4.2", "5.0", "5.1"]
         exclude:
-          - python: "3.11"
-            django: "3.2"
-          - python: "3.12"
-            django: "3.2"
-          - python: "3.11"
-            django: "4.0"
-          - python: "3.12"
-            django: "4.0"
-          - python: "3.8"
-            django: "5.0"
           - python: "3.9"
             django: "5.0"
+          - python: "3.9"
+            django: "5.1"
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project
@@ -45,11 +37,11 @@ jobs:
     steps:
     - name: Start MySQL
       run: sudo systemctl start mysql.service
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install system Python build deps for psycopg2
       run: sudo apt-get install python3-dev python3.11-dev
     - name: Set up Python ${{ matrix.python }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python }}
     - name: Upgraded pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: sudo systemctl start mysql.service
     - uses: actions/checkout@v4
     - name: Install system Python build deps for psycopg2
-      run: sudo apt-get install python3-dev python3.11-dev
+      run: sudo apt-get install python3-dev
     - name: Set up Python ${{ matrix.python }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
             django: "5.0"
           - python: "3.9"
             django: "5.1"
+          - python: "3.13"
+            django: "4.2"
+          - python: "3.13"
+            django: "5.0"
         database_url:
           - postgres://runner:password@localhost/project
           - mysql://root:root@127.0.0.1/project

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Simple database-backed job queue. Jobs are defined in your settings, and are pro
 Asynchronous tasks are run via a *job queue*. This system is designed to support multi-step job workflows.
 
 Supported and tested against:
-- Django 3.2, 4.0, 4.1, 4.2, 5.0
-- Python 3.8, 3.9, 3.10, 3.11, 3.12
+- Django 4.2, 5.0, 5.1
+- Python 3.9, 3.10, 3.11, 3.12, 3.13
 
 ## Getting Started
 

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as datetime_timezone
 import mock
 
 import freezegun
-from django.core.management import call_command, CommandError
+from django.core.management import call_command
 from django.test import TestCase
 from django.test.utils import override_settings
 from django.utils import timezone
@@ -11,14 +11,6 @@ from django_dbq.management.commands.worker import Worker
 from django_dbq.models import Job
 
 from io import StringIO
-
-
-try:
-    utc = timezone.utc
-except AttributeError:
-    from datetime import timezone as datetime_timezone
-
-    utc = datetime_timezone.utc
 
 
 def test_task(job=None):
@@ -253,7 +245,8 @@ class JobTestCase(TestCase):
     def test_ignores_jobs_until_run_after_is_in_the_past(self):
         job_1 = Job.objects.create(name="testjob")
         job_2 = Job.objects.create(
-            name="testjob", run_after=datetime(2021, 11, 4, 8, tzinfo=utc)
+            name="testjob",
+            run_after=datetime(2021, 11, 4, 8, tzinfo=datetime_timezone.utc),
         )
 
         with freezegun.freeze_time(datetime(2021, 11, 4, 7)):

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone as datetime_timezone
-import mock
+from unittest import mock
 
 import freezegun
 from django.core.management import call_command

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ author = "DabApps"
 author_email = "contact@dabapps.com"
 license = "BSD"
 install_requires = [
-    "Django>=3.1",
+    "Django>=4.2",
 ]
 
 long_description = """Simple database-backed job queue system"""
@@ -82,5 +82,5 @@ setup(
     package_data=get_package_data(package),
     install_requires=install_requires,
     classifiers=[],
-    python_requires=">=3.6"
+    python_requires=">=3.9"
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
-mysqlclient==1.4.6
-freezegun==0.3.12
-mock==3.0.5
-dj-database-url==0.5.0
-psycopg2==2.9.5
-black==24.3.0
+mysqlclient==2.2.7
+freezegun==1.5.1
+dj-database-url==2.3.0
+psycopg2==2.9.10
+black==24.10.0


### PR DESCRIPTION
Also:

* Bump some actions packages
* Bump test requirements
* Install latest point release of each tested version of Django and Python
* Remove hacks that were only needed to support older versions