### PR TITLE
Feature to exclude future jobs from queue depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ queue_depths = Job.get_queue_depths()
 print(queue_depths)  # {"default": 1, "other_queue": 1}
 ```
 
+You can also exclude jobs which exist but are scheduled to be run in the future from the queue depths, where `run_after` is set to a future time from now. To do this set the `exclude_future_jobs` kwarg like so:
+```python
+queue_depths = Job.get_queue_depths(exclude_future_jobs=True)
+```
+
 **Important:** When checking queue depths, do not assume that the key for your queue will always be available. Queue depths of zero won't be included
 in the dict returned by this method.
 
@@ -311,6 +316,8 @@ manage.py worker [queue_name] [--rate_limit]
 ##### manage.py queue_depth
 If you'd like to check your queue depth from the command line, you can run `manage.py queue_depth [queue_name [queue_name ...]]` and any
 jobs in the "NEW" or "READY" states will be returned.
+
+If you wish to exclude jobs which are scheduled to be run in the future you can add `--exclude_future_jobs` to the command.
 
 **Important:** If you misspell or provide a queue name which does not have any jobs, a depth of 0 will always be returned.
 

--- a/django_dbq/management/commands/queue_depth.py
+++ b/django_dbq/management/commands/queue_depth.py
@@ -8,10 +8,13 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument("queue_name", nargs="*", default=["default"], type=str)
+        parser.add_argument("--exclude_future_jobs", default=False, type=bool)
 
     def handle(self, *args, **options):
         queue_names = options["queue_name"]
-        queue_depths = Job.get_queue_depths()
+        queue_depths = Job.get_queue_depths(
+            exclude_future_jobs=options["exclude_future_jobs"]
+        )
 
         queue_depths_string = " ".join(
             [

--- a/django_dbq/tests.py
+++ b/django_dbq/tests.py
@@ -71,12 +71,17 @@ class WorkerManagementCommandTestCase(TestCase):
         self.assertTrue("test_queue" in output)
 
 
+@freezegun.freeze_time("2025-01-01T12:00:00Z")
 @override_settings(JOBS={"testjob": {"tasks": ["a"]}})
 class JobModelMethodTestCase(TestCase):
     def test_get_queue_depths(self):
         Job.objects.create(name="testjob", queue_name="default")
         Job.objects.create(name="testjob", queue_name="testworker")
-        Job.objects.create(name="testjob", queue_name="testworker")
+        Job.objects.create(
+            name="testjob",
+            queue_name="testworker",
+            run_after=timezone.make_aware(datetime(2025, 1, 1, 13, 0, 0)),
+        )
         Job.objects.create(
             name="testjob", queue_name="testworker", state=Job.STATES.FAILED
         )
@@ -86,6 +91,24 @@ class JobModelMethodTestCase(TestCase):
 
         queue_depths = Job.get_queue_depths()
         self.assertDictEqual(queue_depths, {"default": 1, "testworker": 2})
+
+    def test_get_queue_depths_exclude_future_jobs(self):
+        Job.objects.create(name="testjob", queue_name="default")
+        Job.objects.create(name="testjob", queue_name="testworker")
+        Job.objects.create(
+            name="testjob",
+            queue_name="testworker",
+            run_after=timezone.make_aware(datetime(2025, 1, 1, 13, 0, 0)),
+        )
+        Job.objects.create(
+            name="testjob", queue_name="testworker", state=Job.STATES.FAILED
+        )
+        Job.objects.create(
+            name="testjob", queue_name="testworker", state=Job.STATES.COMPLETE
+        )
+
+        queue_depths = Job.get_queue_depths(exclude_future_jobs=True)
+        self.assertDictEqual(queue_depths, {"default": 1, "testworker": 1})
 
 
 @override_settings(JOBS={"testjob": {"tasks": ["a"]}})


### PR DESCRIPTION
New feature: `exclude_future_jobs` for `get_queue_depths`

When using `get_queue_depths` to get the queue depth health for metrics and health it includes all READY/NEW jobs regardless of `run_after`. This is artificially inflating the depth for our use case where many jobs are being created to run at a time in the future and are not _really_ contributing to the current queue backlog.

As an option to handle this, in this PR I have added a kwarg `exclude_future_jobs` which applies a filter to the jobs contributing to the queue depth count where jobs with a `run_after` and it is in the future are ignored. This is available both via the model API and through the `queue_depth` management command.

To maintain existing compatability this is optional and by default continues to use existing behaviour.